### PR TITLE
Introduce leak rate for checkpoints.

### DIFF
--- a/cu-fall-event-2022.bash
+++ b/cu-fall-event-2022.bash
@@ -24,9 +24,7 @@ fi
 
 set -e
 
-# TOTAL_SUPPLY=$(autocorns biologist total-supply --network $BROWNIE_NETWORK --address $CU_ADDRESS)
-
-TOTAL_SUPPLY=1000
+TOTAL_SUPPLY=$(autocorns biologist total-supply --network $BROWNIE_NETWORK --address $CU_ADDRESS)
 
 echo "Total supply: $TOTAL_SUPPLY"
 

--- a/cu-fall-event-2022.bash
+++ b/cu-fall-event-2022.bash
@@ -24,7 +24,9 @@ fi
 
 set -e
 
-TOTAL_SUPPLY=$(autocorns biologist total-supply --network $BROWNIE_NETWORK --address $CU_ADDRESS)
+# TOTAL_SUPPLY=$(autocorns biologist total-supply --network $BROWNIE_NETWORK --address $CU_ADDRESS)
+
+TOTAL_SUPPLY=1000
 
 echo "Total supply: $TOTAL_SUPPLY"
 
@@ -33,26 +35,30 @@ time autocorns biologist dnas \
     --address $CU_ADDRESS \
     --start 1 \
     --end $TOTAL_SUPPLY \
-    --checkpoint "$DATA_DIR/dnas.json"
+    --checkpoint "$DATA_DIR/dnas.json" \
+    --leak-rate 0.05
 
 time autocorns biologist metadata \
     --network $BROWNIE_NETWORK \
     --address $CU_ADDRESS \
     --start 1 \
     --end $TOTAL_SUPPLY \
-    --checkpoint "$DATA_DIR/metadata.json"
+    --checkpoint "$DATA_DIR/metadata.json" \
+    --leak-rate 0.05
 
 time autocorns biologist mythic-body-parts \
     --network $BROWNIE_NETWORK \
     --address $CU_ADDRESS \
     --dnas "$DATA_DIR/dnas.json" \
-    --checkpoint "$DATA_DIR/mythic-body-parts.json"
+    --checkpoint "$DATA_DIR/mythic-body-parts.json" \
+    --leak-rate 0.05
 
 time autocorns biologist stats \
     --network $BROWNIE_NETWORK \
     --address $CU_ADDRESS \
     --dnas "$DATA_DIR/dnas.json" \
-    --checkpoint "$DATA_DIR/stats.json"
+    --checkpoint "$DATA_DIR/stats.json" \
+    --leak-rate 0.05
 
 time autocorns biologist moonstream-events \
     -n breeding_hatching_leaderboard_events \


### PR DESCRIPTION
<!-- Thank you for your contribution. -->
<!-- Filling in the sections below will provide us with some context when we are reviewing your pull request. -->

## Changes

Makes it possible to leak data from checkpoints. The reason for this is to make checkpoints refresh more smoothly, as opposed to the entire checkpoint refreshing at once after the expiration time.

<!-- Please leave a short description of the changes you have made in this pull request. -->
<!-- If applicable, this is the place to discuss alternatives you considered and tradeoffs you made. -->

## How to test these changes?

Tested locally (look at intermediate commit on PR).

<!-- Describe how you tested the changes in this pull request. -->
<!-- Describe how someone else could reproduce your tests. -->

## Related issues

<!-- Is this PR related to any of the issues at https://github.com/orgs/bugout-dev/projects/3 ? -->
<!-- If this PR resolves any of those issues, add a line in the format "Resolves <link to isssue>". -->

<!-- Thanks again! :) -->
